### PR TITLE
feat: votemarket v2 recipients reverse-map (script + daily cron)

### DIFF
--- a/.github/workflows/update-votemarket-recipients.yml
+++ b/.github/workflows/update-votemarket-recipients.yml
@@ -1,0 +1,42 @@
+name: Update Votemarket Recipients
+
+on:
+  schedule:
+    - cron: "0 4 * * *" # At 04:00 every day
+  workflow_dispatch: # Allows the workflow to be triggered manually
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Use Node.js 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run script to update Votemarket recipients data
+        run: pnpm tsx scripts/votemarket/updateRecipients.ts
+
+      - name: Commit and push if changes found
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "Stake DAO API update"
+          git add api/votemarket/recipients.json
+          if ! git diff --staged --quiet; then
+            git commit -m "$(date +"%Y-%m-%d %H:%M:%S"): Auto-update votemarket recipients data"
+            git pull --rebase origin main
+            git push
+          fi
+        shell: bash

--- a/api/votemarket/recipients.json
+++ b/api/votemarket/recipients.json
@@ -1,0 +1,89 @@
+{
+  "epochs": {
+    "balancer": 1783555200,
+    "curve": 1783555200,
+    "frax": 1783555200,
+    "fxn": 1783555200,
+    "pendle": 1783555200
+  },
+  "recipients": {
+    "0x0000000014814b037cf4a091fe00cba2defc6115": [
+      {
+        "forwarder": "0x52f541764e6e90eebc5c21ff570de0e2d63766b6",
+        "protocol": "curve",
+        "chainId": 42161,
+        "platform": "0x8c2c5a295450ddff4cb360ca73fccc12243d14d9"
+      },
+      {
+        "forwarder": "0x52f541764e6e90eebc5c21ff570de0e2d63766b6",
+        "protocol": "curve",
+        "chainId": 8453,
+        "platform": "0x8c2c5a295450ddff4cb360ca73fccc12243d14d9"
+      }
+    ],
+    "0x0000000095310137125f82f37fbe5d2f99279947": [
+      {
+        "forwarder": "0x989aeb4d175e16225e39e87d0d97a3360524ad80",
+        "protocol": "curve",
+        "chainId": 42161,
+        "platform": "0x5e5c922a5eeab508486eb906ebe7bdffb05d81e5"
+      },
+      {
+        "forwarder": "0x989aeb4d175e16225e39e87d0d97a3360524ad80",
+        "protocol": "curve",
+        "chainId": 42161,
+        "platform": "0x8c2c5a295450ddff4cb360ca73fccc12243d14d9"
+      },
+      {
+        "forwarder": "0x989aeb4d175e16225e39e87d0d97a3360524ad80",
+        "protocol": "curve",
+        "chainId": 8453,
+        "platform": "0x8c2c5a295450ddff4cb360ca73fccc12243d14d9"
+      }
+    ],
+    "0x2343bda7b40c4197c4d472ab2f4863e2c434af82": [
+      {
+        "forwarder": "0xd11a4ee017ca0beca8fa45ff2abfe9c6267b7881",
+        "protocol": "fxn",
+        "chainId": 42161,
+        "platform": "0x155a7cf21f8853c135bdeba27fea19674c65f2b4"
+      }
+    ],
+    "0x4444aaaacdba5580282365e25b16309bd770ce4a": [
+      {
+        "forwarder": "0xf147b8125d2ef93fb6965db97d6746952a133934",
+        "protocol": "curve",
+        "chainId": 42161,
+        "platform": "0x5e5c922a5eeab508486eb906ebe7bdffb05d81e5"
+      },
+      {
+        "forwarder": "0xf147b8125d2ef93fb6965db97d6746952a133934",
+        "protocol": "curve",
+        "chainId": 42161,
+        "platform": "0x8c2c5a295450ddff4cb360ca73fccc12243d14d9"
+      },
+      {
+        "forwarder": "0xf147b8125d2ef93fb6965db97d6746952a133934",
+        "protocol": "curve",
+        "chainId": 8453,
+        "platform": "0x8c2c5a295450ddff4cb360ca73fccc12243d14d9"
+      }
+    ],
+    "0xa05c5f4a91be37f82a5ddfea970c6d32675fa737": [
+      {
+        "forwarder": "0x75736518075a01034fa72d675d36a47e9b06b2fb",
+        "protocol": "fxn",
+        "chainId": 42161,
+        "platform": "0x155a7cf21f8853c135bdeba27fea19674c65f2b4"
+      }
+    ],
+    "0xfcbbb4f7653770a040e1b14574ed5577d0a18eab": [
+      {
+        "forwarder": "0xc40549aa1d05c30af23a1c4a5af6ba11fcafe23f",
+        "protocol": "fxn",
+        "chainId": 42161,
+        "platform": "0x155a7cf21f8853c135bdeba27fea19674c65f2b4"
+      }
+    ]
+  }
+}

--- a/scripts/votemarket/updateRecipients.ts
+++ b/scripts/votemarket/updateRecipients.ts
@@ -1,0 +1,157 @@
+import fs from 'fs'
+import path from 'path'
+import { createPublicClient, http, parseAbi } from 'viem'
+import { arbitrum, base, mainnet, optimism, polygon } from 'viem/chains'
+import { RPC } from '../../src/lib/constants'
+import { chunk, readFile } from '../utils'
+
+// Votemarket v2 platforms store a forwarder -> recipient mapping
+// (`recipients(address)`) but emit no event when it is set, so the UI cannot
+// discover which forwarders point at a connected recipient. This script
+// enumerates the voters from the published weekly data
+// (api/votemarket/{epoch}/{protocol}/index.json), multicalls
+// `recipients(voter)` on every platform/chain found there, and writes the
+// inverted mapping to api/votemarket/recipients.json.
+
+const VM_DIR = 'api/votemarket'
+const OUTPUT_PATH = `${VM_DIR}/recipients.json`
+const EPOCH_LOOKBACK = 4
+const MULTICALL_CHUNK = 500
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+
+const RECIPIENTS_ABI = parseAbi(['function recipients(address) view returns (address)'])
+const CHAINS = {
+  [mainnet.id]: mainnet,
+  [optimism.id]: optimism,
+  [polygon.id]: polygon,
+  [base.id]: base,
+  [arbitrum.id]: arbitrum,
+}
+
+interface ForwardEntry {
+  forwarder: string
+  protocol: string
+  chainId: number
+  platform: string
+}
+
+const listDirs = (dir: string) =>
+  fs.existsSync(dir)
+    ? fs
+        .readdirSync(dir, { withFileTypes: true })
+        .filter((e) => e.isDirectory())
+        .map((e) => e.name)
+    : []
+
+// Latest index.json per protocol across the last EPOCH_LOOKBACK published epochs
+const getProtocolIndexes = () => {
+  const epochs = listDirs(VM_DIR)
+    .filter((name) => /^\d+$/.test(name))
+    .map(Number)
+    .sort((a, b) => b - a)
+    .slice(0, EPOCH_LOOKBACK)
+
+  const indexes: Record<string, { epoch: number; data: any }> = {}
+  for (const epoch of epochs) {
+    for (const protocol of listDirs(path.join(VM_DIR, `${epoch}`))) {
+      if (indexes[protocol]) continue
+      const indexPath = path.join(VM_DIR, `${epoch}`, protocol, 'index.json')
+      if (fs.existsSync(indexPath)) indexes[protocol] = { epoch, data: readFile({ path: indexPath }) }
+    }
+  }
+  return indexes
+}
+
+// {`${chainId}-${platform_lc}`: Set<voter_lc>} from an index.json
+const collectVoters = (indexData: any) => {
+  const voters: Record<string, Set<string>> = {}
+  for (const [platform, chains] of Object.entries(indexData.platforms ?? {})) {
+    for (const [chainId, chainData] of Object.entries(chains as Record<string, any>)) {
+      const key = `${chainId}-${platform.toLowerCase()}`
+      if (!voters[key]) voters[key] = new Set()
+      for (const gauge of Object.values((chainData.gauges ?? {}) as Record<string, any>)) {
+        for (const user of Object.keys(gauge.users ?? {})) voters[key].add(user.toLowerCase())
+        for (const listed of Object.values((gauge.listed_users ?? {}) as Record<string, any>)) {
+          for (const user of Object.keys(listed)) voters[key].add(user.toLowerCase())
+        }
+      }
+    }
+  }
+  return voters
+}
+
+// {forwarder_lc: recipient_lc} for voters with a recipient set on the platform
+const fetchPlatformRecipients = async (chainId: number, platform: string, voters: string[]) => {
+  const chain = CHAINS[chainId]
+  if (!chain || !RPC[chainId]) {
+    console.warn(`No chain/RPC configured for chain ${chainId}, skipping ${platform}`)
+    return {}
+  }
+  const client = createPublicClient({ chain, transport: http(RPC[chainId]) })
+
+  const found: Record<string, string> = {}
+  for (const votersChunk of chunk(voters.sort(), MULTICALL_CHUNK)) {
+    const results = await client.multicall({
+      contracts: votersChunk.map((voter: string) => ({
+        address: platform as `0x${string}`,
+        abi: RECIPIENTS_ABI,
+        functionName: 'recipients',
+        args: [voter as `0x${string}`],
+      })),
+    })
+    votersChunk.forEach((voter: string, i: number) => {
+      const r = results[i]
+      if (r.status !== 'success') return
+      const recipient = (r.result as string).toLowerCase()
+      if (recipient !== ZERO_ADDRESS && recipient !== voter) found[voter] = recipient
+    })
+  }
+  return found
+}
+
+const updateVotemarketRecipients = async () => {
+  const indexes = getProtocolIndexes()
+  const epochs: Record<string, number> = {}
+  const recipients: Record<string, ForwardEntry[]> = {}
+
+  for (const [protocol, { epoch, data }] of Object.entries(indexes)) {
+    epochs[protocol] = epoch
+    for (const [key, voters] of Object.entries(collectVoters(data))) {
+      if (voters.size === 0) continue
+      const [chainIdStr, platform] = key.split('-')
+      const chainId = Number(chainIdStr)
+      const forwards = await fetchPlatformRecipients(chainId, platform, [...voters])
+      for (const [forwarder, recipient] of Object.entries(forwards)) {
+        if (!recipients[recipient]) recipients[recipient] = []
+        recipients[recipient].push({ forwarder, protocol, chainId, platform })
+      }
+      console.info(
+        `${protocol} ${platform} chain ${chainId}: ${voters.size} voters, ${Object.keys(forwards).length} forwarding`,
+      )
+    }
+  }
+
+  for (const entries of Object.values(recipients)) {
+    entries.sort((a, b) =>
+      `${a.protocol}-${a.chainId}-${a.platform}-${a.forwarder}`.localeCompare(
+        `${b.protocol}-${b.chainId}-${b.platform}-${b.forwarder}`,
+      ),
+    )
+  }
+  const payload = {
+    epochs,
+    recipients: Object.fromEntries(Object.entries(recipients).sort(([a], [b]) => a.localeCompare(b))),
+  }
+
+  if (fs.existsSync(OUTPUT_PATH)) {
+    const existing = readFile({ path: OUTPUT_PATH })
+    if (JSON.stringify(existing.recipients) === JSON.stringify(payload.recipients)) {
+      console.info('Recipients map unchanged, skipping write.')
+      return
+    }
+  }
+  fs.writeFileSync(OUTPUT_PATH, JSON.stringify(payload, null, 2))
+  console.info(`Wrote ${OUTPUT_PATH}: ${Object.keys(payload.recipients).length} recipients`)
+}
+
+updateVotemarketRecipients()


### PR DESCRIPTION
- Votemarket v2 platforms emit no event on `setRecipient`, so the UI cannot discover which forwarders point at a connected recipient
- `scripts/votemarket/updateRecipients.ts` reads the published weekly indexes (protocols discovered by listing `api/votemarket/{epoch}/`), multicalls `recipients()` per platform/chain, and writes the inverted map to `api/votemarket/recipients.json` — same pattern as `updateMerklesRecipients.ts`
- Daily cron + manual dispatch; commits only when the map changed. Initial data included
- Consumed by stake-dao/monorepo#1261; replaces the heavier stake-dao/automation-jobs#914 + workflows#326 + orchestrator#56