### PR TITLE
fix(ENG-2000): make a failed strategy update actually fail the job

### DIFF
--- a/scripts/strategies/updateCurveStrats.ts
+++ b/scripts/strategies/updateCurveStrats.ts
@@ -36,6 +36,18 @@ const updateCurveStrats = async () => {
       error: '❌ - An error occured during the Curve strategies update.',
     },
   })
+
+  // Written first, then raised. `writeFileFromPromise` skips a rejected entry, so the previously
+  // published JSON is preserved — but swallowing the rejection here made the caller's exit code
+  // useless: a hub outage on mainnet left this function resolving normally, `updateStrats.ts`
+  // counting zero failures, and the workflow committing the other protocols with a green step.
+  const rejected = [curveDataMainnet, curveDataArbitrum, curveData].filter((r) => r.status === 'rejected')
+  if (rejected.length) {
+    throw new AggregateError(
+      rejected.map((r) => (r as PromiseRejectedResult).reason),
+      `${rejected.length}/3 Curve strategy file(s) could not be produced`,
+    )
+  }
 }
 
 export const updateCurveStrats_v2 = async () => {

--- a/scripts/strategies/updatePassiveStrats.ts
+++ b/scripts/strategies/updatePassiveStrats.ts
@@ -35,6 +35,17 @@ const updatePassiveStrats = async () => {
       error: '❌ - An error occured during the Passive strategies update.',
     },
   })
+
+  // Same reason as `updateCurveStrats`: the previous JSON is preserved by the writer, but the
+  // rejection has to reach `updateStrats.ts` for the workflow step to fail and the commit to be
+  // skipped. Swallowed here, the exit code never fired.
+  const rejected = [passiveDataMainnet, passiveDataPolygon, passiveData].filter((r) => r.status === 'rejected')
+  if (rejected.length) {
+    throw new AggregateError(
+      rejected.map((r) => (r as PromiseRejectedResult).reason),
+      `${rejected.length}/3 passive strategy file(s) could not be produced`,
+    )
+  }
 }
 
 export default updatePassiveStrats

--- a/scripts/updateStrats.ts
+++ b/scripts/updateStrats.ts
@@ -24,11 +24,23 @@ const updateStrats = async () => {
     updatePassiveStrats(),
   ])
 
+  let failed = 0
+
   for (const [index, result] of promises.entries()) {
     if (result.status === 'rejected') {
+      failed++
       console.error(`❌ - ${PROMISES_INDEX[index]} strats update fails`)
       console.error(result)
     }
+  }
+
+  // `allSettled` deliberately lets the other protocols finish, but the process must still exit
+  // non-zero: `writeFileFromPromise` skips the write on a rejection, so the previous JSON is
+  // preserved — and without this the step reported success and the commit step ran anyway,
+  // hiding the fact that a protocol had produced nothing.
+  if (failed > 0) {
+    console.error(`❌ - ${failed}/${promises.length} protocol update(s) failed — exiting non-zero`)
+    process.exitCode = 1
   }
 }
 

--- a/scripts/updateV2Strats.ts
+++ b/scripts/updateV2Strats.ts
@@ -9,11 +9,21 @@ const PROMISES_INDEX = {
 const updateStrats_v2 = async () => {
   const promises = await Promise.allSettled([updateCurveStrats_v2(), updateBalancerStrats_v2()])
 
+  let failed = 0
+
   for (const [index, result] of promises.entries()) {
     if (result.status === 'rejected') {
+      failed++
       console.error(`❌ - ${PROMISES_INDEX[index]} strats update fails`)
       console.error(result)
     }
+  }
+
+  // Same reason as `updateStrats.ts`: a rejection preserves the previous JSON, but the step has
+  // to report failure so the commit step does not run on a partial update.
+  if (failed > 0) {
+    console.error(`❌ - ${failed}/${promises.length} v2 protocol update(s) failed — exiting non-zero`)
+    process.exitCode = 1
   }
 }
 


### PR DESCRIPTION
Linear: [ENG-2000](https://linear.app/stake-dao/issue/ENG-2000/replace-curve-api)

Trouvé par une revue Codex du chantier ENG-2000. Indépendant du reste : ce correctif vaut aussi sans la migration.

## Le problème

Le workflow régénère les JSON puis committe :

```yaml
- run: pnpm tsx scripts/updateStrats.ts
- run: git add … && git commit … && git push
```

Les scripts utilisent `Promise.allSettled` pour qu'un protocole en panne n'empêche pas les autres de finir — c'est voulu. Mais ils se contentaient de **logger** les rejets et rendaient la main normalement.

Donc : panne du hub → le reader lève → `writeFileFromPromise` saute l'écriture, donc **le JSON précédent est bien préservé** et aucun zéro n'est publié → **mais le script sort en code 0**, l'étape passe au vert, et l'étape de commit s'exécute quand même.

Le job réussissait donc alors qu'un protocole n'avait rien produit, sans alerte.

## Pourquoi 4 fichiers et pas 2

Corriger les deux scripts extérieurs **ne suffisait pas** : `updateCurveStrats` et `updatePassiveStrats` ont **leur propre `Promise.allSettled` interne**, qui absorbait le rejet avant qu'il n'atteigne le compteur extérieur.

| Fichier | Changement |
|---|---|
| `strategies/updateCurveStrats.ts` | lève un `AggregateError` **après** avoir écrit ce qui a réussi |
| `strategies/updatePassiveStrats.ts` | idem |
| `updateStrats.ts` | `process.exitCode = 1` si un protocole a échoué |
| `updateV2Strats.ts` | idem |

L'ordre compte : on écrit d'abord, on lève ensuite. Les JSON valides restent à jour, seul le protocole en panne garde son fichier précédent.

## Résultat

Avant : hub en 503 → étape verte, commit des autres résultats, silence.
Après : étape rouge, commit sauté, `❌ - 1/6 protocol update(s) failed — exiting non-zero`.

C'est le pendant côté publication du travail fait côté hub : ne jamais présenter une absence de donnée comme une donnée.

## À prévoir au prochain passage sur ce repo

`src/lib/strategies/v2.ts:9` code en dur l'URL du hub, ce qui rend le chemin v2 intestable en local sans patcher le fichier. À rendre surchargeable lors du bump de `@stake-dao/reader` (phase 5.7 d'ENG-2000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)